### PR TITLE
Use a different clear screen command based on operating system

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
 import utils
 from colorama import Fore, init
+import os
 from os import system
 from datetime import datetime
 import requests
 
 
 init()
-system("cls")
+system("clear") if os.name == 'posix' else system("cls")
 version = "1.0.1"
 
 


### PR DESCRIPTION
`cls` doesn't work on Linux, so we do a check to see if they are on Linux and use the working command `clear` if they are. 